### PR TITLE
Probably fixed skip turn bug (See below)

### DIFF
--- a/src/net/fe/overworldStage/ClientOverworldStage.java
+++ b/src/net/fe/overworldStage/ClientOverworldStage.java
@@ -350,7 +350,6 @@ public class ClientOverworldStage extends OverworldStage {
 	public void end(){
 		FEMultiplayer.getClient().sendMessage(new EndTurn());
 		selectedUnit = null;
-		removeExtraneousEntities();
 	}
 	
 	/* (non-Javadoc)
@@ -358,6 +357,7 @@ public class ClientOverworldStage extends OverworldStage {
 	 */
 	@Override
 	protected void doEndTurn(int playerID) {
+		removeExtraneousEntities();
 		super.doEndTurn(playerID);
 		context.cleanUp();
 		// reset assists

--- a/src/net/fe/overworldStage/OverworldStage.java
+++ b/src/net/fe/overworldStage/OverworldStage.java
@@ -269,17 +269,23 @@ public class OverworldStage extends Stage {
 						chat.add(p, chatMsg.text);
 			}
 			else if(message instanceof EndTurn) {
-				if(this instanceof ClientOverworldStage){
-					((EndTurn) message).checkHp(false);
-				} else {
-					((EndTurn) message).checkHp(true);
+				//Only end the turn if it is this player's turn to end. (Or, if for some reason we want to let
+				//the server end turns in the future.
+				System.out.println("" + message.origin + " " + currentPlayer);
+				if(message.origin == getCurrentPlayer().getID() || message.origin == 0){
+
+					if(this instanceof ClientOverworldStage){
+						((EndTurn) message).checkHp(false);
+					} else {
+						((EndTurn) message).checkHp(true);
+					}
+					doEndTurn(message.origin);
+					currentPlayer++;
+					if(currentPlayer >= turnOrder.size()) {
+						currentPlayer = 0;
+					}
+					doStartTurn(message.origin);
 				}
-				doEndTurn(message.origin);
-				currentPlayer++;
-				if(currentPlayer >= turnOrder.size()) {
-					currentPlayer = 0;
-				}
-				doStartTurn(message.origin);
 			}
 			else if(message instanceof QuitMessage) {
 				Player leaver = null;


### PR DESCRIPTION
I say probably, because I can't test it on this computer - I was unable
to replicate the bug in the first place.  At any rate, players whose
turn it is not should not be able to end the turn.  I did not want to do
the same thing for CommandMessages until I am sure that there are none
that are intended to be allowed on the enemy's turn.

Because I know I'm going to get a comment about it, there are some of
the bugs with this that aren't going to be possible to fix server-side
without a moderate rewrite of the netcode, and either that or the
client-side fix will take more time than I have tonight.

Either way, someone who can reliably replicate the skip turn bug should test this before merging it in, as again, I can't.  It SHOULD work, but all I know for sure is that it is no worse off than it was without the fix.